### PR TITLE
fix: #18 DateTimePicker 모달이 보이지 않는 문제 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ web-build/
 
 # IDE
 .idea
+
+# app.json
+app.json
+
+# config
+config/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^11.2.0",
-        "@react-native-community/datetimepicker": "^7.0.1",
+        "@react-native-community/datetimepicker": "6.5.2",
         "@react-navigation/bottom-tabs": "^6.4.0",
         "@react-navigation/native": "^6.0.13",
         "@react-navigation/native-stack": "^6.9.1",
@@ -23,7 +23,7 @@
         "react-native": "0.70.8",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",
         "react-native-maps": "1.3.2",
-        "react-native-modal-datetime-picker": "^15.0.0",
+        "react-native-modal-datetime-picker": "14.0.1",
         "react-native-safe-area-context": "^4.4.1",
         "react-native-screens": "^3.18.2",
         "react-native-web": "~0.18.9",
@@ -4669,9 +4669,9 @@
       }
     },
     "node_modules/@react-native-community/datetimepicker": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-7.0.1.tgz",
-      "integrity": "sha512-EllGpk6kbEUCvBDDTnHNLJhfkPOI2Yy+KWj3ImOeM9lAA6CkmFlj/mXGCEbfD/Ddu1U7egO/AwqOmG/Bx3IcEQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-6.5.2.tgz",
+      "integrity": "sha512-9K3zhIH1zmpIGSG3GJTWLIoAx+sR4kJ1wqpGKMwWJ5IYXBsFxMdvGw023t0pz2CQStlnNbbNhnZY/HMYFBCsCg==",
       "dependencies": {
         "invariant": "^2.2.4"
       }
@@ -13532,14 +13532,14 @@
       }
     },
     "node_modules/react-native-modal-datetime-picker": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-15.0.0.tgz",
-      "integrity": "sha512-cHeFEYHUhyIk+Mt9C6RVseg/VMGR4XcxdU9SibF5RMCXiXhrwMkFy7203xg1S331pzCF/Oqhvi4Jh0pYMrTFtQ==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-14.0.1.tgz",
+      "integrity": "sha512-wQt4Pjxt2jiTsVhLMG0E7WrRTYBEQx2d/nUrFVCbRqJ7lrXocXaT5UZsyMpV93TnKcyut62OprbO88wYq/vh0g==",
       "dependencies": {
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@react-native-community/datetimepicker": ">=6.7.0",
+        "@react-native-community/datetimepicker": ">=3.0.0",
         "react-native": ">=0.65.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@react-native-community/cli-debugger-ui": "^11.2.0",
-    "@react-native-community/datetimepicker": "^7.0.1",
     "@react-navigation/bottom-tabs": "^6.4.0",
     "@react-navigation/native": "^6.0.13",
     "@react-navigation/native-stack": "^6.9.1",
@@ -26,14 +25,15 @@
     "react-native": "0.70.8",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.3.2",
-    "react-native-modal-datetime-picker": "^15.0.0",
     "react-native-safe-area-context": "^4.4.1",
     "react-native-screens": "^3.18.2",
     "react-native-web": "~0.18.9",
     "react-redux": "^8.0.5",
     "redux": "^4.2.0",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.4.2"
+    "redux-thunk": "^2.4.2",
+    "@react-native-community/datetimepicker": "6.5.2",
+    "react-native-modal-datetime-picker": "14.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
1. dependency 문제 발생.
```$ expo install react-native-modal-datetime-picker@14.0.1  @react-native-community/datetimepicker```
```{
    dependency: {
    "@react-native-community/datetimepicker": "6.5.2",
    "react-native-modal-datetime-picker": "14.0.1"
    },
}