### PR TITLE
feat: 로그인 로직 구현, 피드 상세 화면 API 연동 및 검색 API 연동 진행 중

### DIFF
--- a/src/@types/FeedInfo.ts
+++ b/src/@types/FeedInfo.ts
@@ -1,10 +1,13 @@
 export type FeedInfo = {
     id:number, 
     content:string, 
+    heartCount:number,
     userName:string,
     placeName:string,
-    createdAt:string, 
-    imageUrl:string
+    updatedAt:string,
+    profileImage:string,
+    imageUrl:string,
+    isLiked:boolean
 }
 
 //     id(feed):number, 

--- a/src/@types/PlaceInfo.ts
+++ b/src/@types/PlaceInfo.ts
@@ -1,6 +1,4 @@
 export type PlaceInfo = {
-    id:string;
-    type:string;
-    name:string;
-    address:string;
+    placeId:string;
+    placeName:string;
 }

--- a/src/RootApp.tsx
+++ b/src/RootApp.tsx
@@ -1,13 +1,30 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer } from '@react-navigation/native';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { getUserInfo, signIn, TypeUserDispatch } from './actions/user';
 import { RootStackNavigation } from './navigations/RootStackNavigation';
 import { SplashView } from './SplashView';
+import { useDispatch } from 'react-redux';
+import { LoginScreen } from './screens/LoginScreen';
+
 
 export const RootApp:React.FC = ()=>{
-    const [initialize, setInitialize] = useState(false);
-
-    if(!initialize){
-        return <SplashView onFinishLoad={()=> setInitialize(true)}/>
+    const [initialize, setInitialize] = useState(false)
+    const dispatch = useDispatch<TypeUserDispatch>();
+    
+    useEffect(() => {
+        removeStorage('@token');
+        getStorage('@token').then((token) => {
+        if (token) {
+            getUserInfo();
+        } else {
+            console.log("no token");
+        }
+        })
+      }, []);
+    
+    if (!initialize) {
+        return <LoginScreen />
     }
 
     return (
@@ -15,4 +32,19 @@ export const RootApp:React.FC = ()=>{
             <RootStackNavigation/>
         </NavigationContainer>
     )
-}
+};
+// get
+export const getStorage = async (key:string) => {
+    const result = await AsyncStorage.getItem(key);
+    return result && JSON.parse(result);
+  };
+  
+  // set
+  export const setStorage = async (key:string, value:any) => {
+    return await AsyncStorage.setItem(key, JSON.stringify(value));
+  };
+  
+  // remove
+  export const removeStorage = async (key:string) => {
+    return await AsyncStorage.removeItem(key);
+  };

--- a/src/RootApp.tsx
+++ b/src/RootApp.tsx
@@ -2,49 +2,73 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer } from '@react-navigation/native';
 import React, { useEffect, useState } from 'react';
 import { getUserInfo, signIn, TypeUserDispatch } from './actions/user';
-import { RootStackNavigation } from './navigations/RootStackNavigation';
+import { HomeStackNavigation } from './navigations/HomeStackNavigation';
+import { createNativeStackNavigator, NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SplashView } from './SplashView';
 import { useDispatch } from 'react-redux';
 import { LoginScreen } from './screens/LoginScreen';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+
+
+
+export type RootStackParamList = {
+  SplashView:undefined
+  Login:undefined
+  Home:undefined
+}
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
 
 
 export const RootApp:React.FC = ()=>{
-    const [initialize, setInitialize] = useState(false)
-    const dispatch = useDispatch<TypeUserDispatch>();
+    // const [initialize, setInitialize] = useState(false)
+    // const dispatch = useDispatch<TypeUserDispatch>();
     
-    useEffect(() => {
-        removeStorage('@token');
-        getStorage('@token').then((token) => {
-        if (token) {
-            getUserInfo();
-        } else {
-            console.log("no token");
-        }
-        })
-      }, []);
+    // useEffect(() => {
+    //     removeStorage('@token');
+    //     getStorage('@token').then((token) => {
+    //     if (token) {
+    //         getUserInfo();
+    //     } else {
+    //         console.log("no token");
+    //     }
+    //     })
+    //   }, []);
     
-    if (!initialize) {
-        return <LoginScreen />
-    }
+    // if (!initialize) {
+    //     return <LoginScreen />
+    // }
 
     return (
         <NavigationContainer>
-            <RootStackNavigation/>
+            <Stack.Navigator initialRouteName='SplashView'>
+              <Stack.Screen name="SplashView" component={SplashView} options={{headerShown: false}} />
+              <Stack.Screen name="Login" component={LoginScreen} options={{headerShown: false}} />
+              <Stack.Screen name="Home" component={HomeStackNavigation} options={{headerShown: false}}/>
+            </Stack.Navigator>
         </NavigationContainer>
     )
 };
-// get
-export const getStorage = async (key:string) => {
-    const result = await AsyncStorage.getItem(key);
-    return result && JSON.parse(result);
-  };
+// // get
+// export const getStorage = async (key:string) => {
+//     const result = await AsyncStorage.getItem(key);
+//     return result && JSON.parse(result);
+//   };
   
-  // set
-  export const setStorage = async (key:string, value:any) => {
-    return await AsyncStorage.setItem(key, JSON.stringify(value));
-  };
+//   // set
+//   export const setStorage = async (key:string, value:any) => {
+//     return await AsyncStorage.setItem(key, JSON.stringify(value));
+//   };
   
-  // remove
-  export const removeStorage = async (key:string) => {
-    return await AsyncStorage.removeItem(key);
-  };
+//   // remove
+//   export const removeStorage = async (key:string) => {
+//     return await AsyncStorage.removeItem(key);
+//   };
+
+export const useRootNavigation = <RouteName extends keyof RootStackParamList>()=>{
+  return useNavigation<NativeStackNavigationProp<RootStackParamList, RouteName>>();
+}
+
+export const useRootRoute = <RouteName extends keyof RootStackParamList>()=>{
+  return useRoute<RouteProp<RootStackParamList, RouteName>>();
+}

--- a/src/SplashView.tsx
+++ b/src/SplashView.tsx
@@ -1,24 +1,28 @@
 import React, { useCallback, useEffect } from 'react';
 import { View, Image } from 'react-native';
 import { useDispatch } from 'react-redux';
-import { signIn, TypeUserDispatch } from './actions/user';
-import { Typography } from './components/Typography';
+import { getUserInfo, TypeUserDispatch } from './actions/user';
 import Splash from '../assets/splash.png';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useRootNavigation } from './RootApp';
 
-export const SplashView:React.FC<{onFinishLoad:()=>void}> = (props)=>{
+export const SplashView:React.FC = ()=>{
     const dispatch = useDispatch<TypeUserDispatch>();
-    const appInit = useCallback(async()=>{
-        await dispatch(signIn());
-        props.onFinishLoad();
-
+    const rootNavigation = useRootNavigation();
+    const appInit = useCallback(async (token:string)=>{
+        console.log("Token Exist!");
+        dispatch(getUserInfo(token));
+        rootNavigation.replace('Home');
     }, [])
     useEffect(()=>{
-        appInit();
-
+        setTimeout(() => {
+            AsyncStorage.getItem('@token').then((value) =>
+            {value === null ? rootNavigation.replace('Login') : appInit(value)});
+        },3000);
     }, [])
     return (
         <View style={{flex:1, alignItems:'center', justifyContent:'center'}}>
-            <Image source={Splash} style={{width: 100 }} />
+            <Image source={Splash} style={{width: '100%', height: '100%'}} />
         </View>
     )
 }

--- a/src/actions/feed.ts
+++ b/src/actions/feed.ts
@@ -3,6 +3,7 @@ import { FeedInfo } from "../@types/FeedInfo";
 import { RootReducer } from "../store";
 import { sleep } from "../utils/utils";
 import axios from "axios";
+import { Config } from "../config";
 
 const BASE_URL = 'http://127.0.0.1:8080' 
 
@@ -77,11 +78,17 @@ export const favoriteFeedFailure = ()=>{
 
 export const getFeedList = ():FeedListThunkAction=> async (dispatch)=>{
     dispatch(getFeedListRequest());
-
-    axios.defaults.headers.common['Authorization'] = `Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIyNCIsInJvbGUiOiJST0xFX1VTRVIiLCJpc3MiOiJkZWJyYWlucyIsImV4cCI6MTY4NjMzMjIwM30.miHHbQyHEHcSGNcnN65hjCoIUpfjOuHUkpYW9qq9VH7f_JJcYdQSnv_PUA1r9FUUdNc5xIGMN3mOPzTw1IqnWg`;
-    axios.get(`${BASE_URL}/posts`).then(res => {
-        console.log(res.data.data);
+    axios.get(`${Config.server}/posts`).then(res => {
         console.log(res.data.data.feeds);
+        // TODO: 피드 좋아요 상태 조회 추가 
+        // const feedList:FeedInfo[] = res.data.data.feeds;
+        // const feedsWithLike:FeedInfo[] = feedList.map(f => {
+        //     axios.get(`${Config.server}/posts/${f.id}/heart`)
+        //     .then(res_like => {return res_like.data.data})
+        //     .catch(err_like => console.log(err_like));
+        //     return 
+        // });
+        // console.log(feedsWithLike);
         dispatch(
             getFeedListSuccess(res.data.data.feeds))    
     }).catch(err => {console.log(err.response)});

--- a/src/actions/search.ts
+++ b/src/actions/search.ts
@@ -1,18 +1,24 @@
+import axios from "axios";
 import { ThunkAction, ThunkDispatch } from "redux-thunk";
-import { BookmarkInfo } from "../@types/BookmarkInfo";
+import { Config } from "../config";
 import { RootReducer } from "../store";
-import { sleep } from "../utils/utils";
+import qs from 'qs'
+import { PlaceInfo } from "../@types/PlaceInfo";
 
 export const GET_SEARCH_REQUEST = 'GET_SEARCH_REQUEST' as const;
 export const GET_SEARCH_SUCCESS = 'GET_SEARCH_SUCCESS' as const;
 export const GET_SEARCH_FAILURE = 'GET_SEARCH_FAILURE' as const;
+
+export const CHANGE_SEARCH_KEYWORD_REQUEST = 'CHANGE_SEARCH_KEYWORD_REQUEST' as const;
+export const CHANGE_SEARCH_KEYWORD_SUCCESS = 'CHANGE_SEARCH_KEYWORD_SUCCESS' as const;
+export const CHANGE_SEARCH_KEYWORD_FAILURE = 'CHANGE_SEARCH_KEYWORD_FAILURE' as const;
 
 export const getSearchRequest = ()=>{
     return {
         type:GET_SEARCH_REQUEST,
     }
 }
-export const getSearchSuccess = (list:BookmarkInfo[])=>{
+export const getSearchSuccess = (list:PlaceInfo[])=>{
 
     return {
         type:GET_SEARCH_SUCCESS,
@@ -25,36 +31,38 @@ export const getSearchFailure = ()=>{
         type:GET_SEARCH_FAILURE
     }
 }
+export const changeSearchKeywordRequest = ()=>{
+    return {
+        type:CHANGE_SEARCH_KEYWORD_REQUEST,
+    }
+}
+export const changeSearchKeywordSuccess = (keyword:string)=>{
 
+    return {
+        type:CHANGE_SEARCH_KEYWORD_SUCCESS,
+        keyword
+    }
+}
 
-export const getSearch = ():SearchThunkAction=> async (dispatch)=>{
+export const changeSearchKeywordFailure = ()=>{
+    return {
+        type:CHANGE_SEARCH_KEYWORD_FAILURE
+    }
+}
+
+export const changeSearchKeyword = (keyword:string):SearchThunkAction=> async (dispatch)=>{
+    dispatch(changeSearchKeywordRequest());
+    dispatch(changeSearchKeywordSuccess(keyword));
+}
+
+export const getSearch = (keyword:string):SearchThunkAction=> async (dispatch)=>{
     dispatch(getSearchRequest());
+    console.log(keyword);
 // TODO: 서버 api로부터 받아오기, axios
-    await sleep(2000)
-    dispatch(
-        getSearchSuccess([
-            {
-                id:'ID_01',
-                category:'restaurants',
-                name:'용용선생1'
-            },
-            {
-                id:'ID_02',
-                category:'restaurants',
-                name:'용용선생2'
-            },
-            {
-                id:'ID_03',
-                category:'restaurants',
-                name:'용용선생3'
-            },
-            {
-                id:'ID_04',
-                category:'restaurants',
-                name:'용용선생4'
-            }
-        ]
-    ))
+    axios.get(`${Config.server}/place?keyword=${keyword}`).then(res => {
+        console.log(res.data.result);
+        dispatch(getSearchSuccess(res.data.result))
+    }).catch(err => console.log(err));
 }
 
 
@@ -64,4 +72,7 @@ export type TypeSearchDispatch = ThunkDispatch<RootReducer, undefined, SearchAct
 export type SearchActions = 
     | ReturnType<typeof getSearchRequest> 
     | ReturnType<typeof getSearchSuccess>
-    | ReturnType<typeof getSearchFailure>;
+    | ReturnType<typeof getSearchFailure>
+    | ReturnType<typeof changeSearchKeywordRequest> 
+    | ReturnType<typeof changeSearchKeywordSuccess>
+    | ReturnType<typeof changeSearchKeywordFailure>;

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -99,10 +99,10 @@ export const signIn = ():UserThunkAction => async (dispatch)=>{
         })
     )
 }
-export const getUserInfo = ():UserThunkAction => async (dispatch)=>{
-    axios.get(`${Config.server}/user`)
+export const getUserInfo = (token:string):UserThunkAction => async (dispatch)=>{
+    axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+    await axios.get(`${Config.server}/user`)
     .then((res) => {
-        console.log(res);
         dispatch(setUserInfo({
             id: res.data.data.userId,
             name: res.data.data.userName,

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -4,6 +4,8 @@ import { UserInfo } from "../@types/UserInfo";
 import { RootReducer } from "../store";
 import { sleep } from "../utils/utils";
 import dayjs from "dayjs";
+import axios from "axios";
+import { Config } from "../config";
 
 export const SET_USER_INFO = 'SET_USER_INFO' as const;
 export const UPDATE_USER_NICKNAME = 'UPDATE_USER_NICKNAME' as const;
@@ -96,6 +98,20 @@ export const signIn = ():UserThunkAction => async (dispatch)=>{
             birth: dayjs().format('YY-MM-DD')
         })
     )
+}
+export const getUserInfo = ():UserThunkAction => async (dispatch)=>{
+    axios.get(`${Config.server}/user`)
+    .then((res) => {
+        console.log(res);
+        dispatch(setUserInfo({
+            id: res.data.data.userId,
+            name: res.data.data.userName,
+            profileImage: res.data.data.profileImage,
+            birth: "23-05-01"
+        }));
+    }).catch(err =>{
+        console.log(err);
+    });
 }
 
 export const getMyFeedList = ():UserThunkAction => async (dispatch)=>{

--- a/src/components/FeedListItem.tsx
+++ b/src/components/FeedListItem.tsx
@@ -10,53 +10,53 @@ import { useDispatch } from 'react-redux';
 
 // id:number, 
 //     content:string, 
+//     heartCount:number,
 //     userName:string,
 //     placeName:string,
-//     createdAt:string, 
+//     updatedAt:string,
+//     profileImage:string,
 //     imageUrl:string
-
-export const FeedListItem:React.FC<{imageUrl:string, feedId:number, placeName:string ,writer:string, writerImg:string, content:string, onPressFeed:()=>void}> = (props)=>{
+export const FeedListItem:React.FC<{feedId:number, content:string, heartCount:number, userName:string, placeName:string, updatedAt:string, profileImage:string, imageUrl:string, onPressFeed:()=>void}> = (props)=>{
     const {width} = useWindowDimensions();
     const dispatch = useDispatch<TypeBookmarkListDispatch>();
 
-    const onPressBookmark = useCallback(()=> {
-        dispatch(postBookmark(325016))
+    const onPressBookmark = useCallback((placeId:number)=> {
+        dispatch(postBookmark(placeId))
     }, []);
     return (
         <Button onPress={props.onPressFeed}>
             <View>
                 <View style={{flexDirection:'row', alignItems:'center', paddingVertical:10, paddingHorizontal:7}}>
-                    <RemoteImage url={props.writerImg} width={30} height={30} style={{borderRadius: 30/2}}/>
+                    <RemoteImage url={props.profileImage} width={36} height={36} style={{borderRadius: 36/2}}/>
                     <Spacer space={5} horizontal/>
                     <View style={{justifyContent: 'flex-start'}}>
-                        <View style={{flexDirection:'row', alignItems:'center'}}>
-                            <Typography fontSize={10} color={'gray'}>{props.placeName}</Typography>
+                        <View style={{flexDirection:'row', alignItems:'center', justifyContent:'center'}}>
+                            <Typography fontSize={11} color={'gray'}>{props.placeName}</Typography>
                             <Spacer space={10} horizontal />
-                            <Pressable onPress={() => onPressBookmark()} style={{backgroundColor:'#764AF1', paddingHorizontal:8, paddingVertical:3, borderRadius:8, flexDirection:'row', alignItems:'center', justifyContent:'center'}}>
-                                <Icon name='star-outline' size={10} color='white'/>
+                            {/* TODO: onPressBookmark에 placeId 추가 */}
+                            <Pressable onPress={() => onPressBookmark()} style={{backgroundColor:'#764AF1', paddingHorizontal:6, paddingVertical:2, borderRadius:8, flexDirection:'row', alignItems:'center', justifyContent:'center'}}>
+                                <Icon name='star-outline' size={9} color='white'/>
                                 <Spacer space={4} horizontal/>
-                                <Typography fontSize={10} color={'white'}>{'장소추가'}</Typography>
+                                <Typography fontSize={9} color={'white'}>{'장소추가'}</Typography>
                             </Pressable>
                         </View>
-                        <Typography fontSize={12}>{props.writer}</Typography>
+                        <Typography fontSize={12} bold>{props.userName}</Typography>
                     </View>
                 </View>
                 {/*<Spacer space={10}/>*/}
                 <RemoteImage url={props.imageUrl} width={width} height={width}/>
 
-                <View style={{paddingHorizontal:12,paddingVertical:12,}}>
-                    <View style={{flexDirection:'row', alignItems:'center',}}>
-                        <Icon name='heart-outline' size={20} color='black'/>
-                        <Spacer space={4} horizontal/>
-                    </View>
+                <View style={{paddingHorizontal:12, paddingVertical:12, flexDirection:'row', alignItems:'center', justifyContent:'space-between'}}>
+                    <Icon name='heart-outline' size={20} color='black'/>
+                    <Typography fontSize={12} color='gray'>{props.updatedAt}</Typography>
                 </View>
                 <View style={{paddingHorizontal:12 }}>
-                    {/*<Typography fontSize={16} color='black'>좋아요 {props.likeCount}개</Typography>*/}
-                    {/*<Spacer space={4}/>*/}
+                    <Typography fontSize={12} color='black'>좋아요 {props.heartCount}개</Typography>
+                    <Spacer space={10}/>
                     <View style={{flexDirection:'row', alignItems:'center',}}>
                         {/*<Typography fontSize={12}>{props.writer}</Typography>*/}
                         {/*<Spacer space={8} horizontal/>*/}
-                        <Typography fontSize={16}>{}</Typography>
+                        <Typography fontSize={16}>{props.content}</Typography>
                     </View>
                 </View>
             </View>

--- a/src/navigations/BottomTabNavigation.tsx
+++ b/src/navigations/BottomTabNavigation.tsx
@@ -8,7 +8,6 @@ import { TypeIconName } from '../components/Icons';
 import {RouteProp, useNavigation, useRoute} from "@react-navigation/native";
 import { MyListScreen } from '../screens/MyListScreen';
 import { SearchScreen } from '../screens/SearchScreen';
-import { LoginScreen } from '../screens/LoginScreen';
 
 export type BottomTabParamList = {
     Space:undefined,
@@ -58,7 +57,7 @@ export const BottomTabNavigation = ()=>{
             <BottomTab.Screen name='MyList' component={MyListScreen} />
             <BottomTab.Screen name='Map' component={MapScreen} />
             <BottomTab.Screen name='Search' component={SearchScreen} />
-            <BottomTab.Screen name='MyPage' component={LoginScreen} />
+            <BottomTab.Screen name='MyPage' component={MyPageScreen} />
         </BottomTab.Navigator>
     )
 }

--- a/src/navigations/HomeStackNavigation.tsx
+++ b/src/navigations/HomeStackNavigation.tsx
@@ -1,6 +1,7 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { createNativeStackNavigator, NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
+import { FeedInfo } from '../@types/FeedInfo';
 import { ImageSelectScreen } from '../screens/ImageSelectScreen';
 import { PlaceSearchScreen } from '../screens/PlaceSearchScreen';
 import { PostDetailScreen } from '../screens/PostDetailScreen';
@@ -9,9 +10,9 @@ import { WritePostScreen } from '../screens/WritePostScreen';
 import { BottomTabNavigation } from './BottomTabNavigation';
 
 
-export type RootStackParamList = {
+export type HomeStackParamList = {
     BottomTab:undefined
-    PostDetail:undefined
+    PostDetail: FeedInfo
     Setting:undefined
     PlaceSearch:undefined
     ImageSelect:undefined
@@ -19,13 +20,12 @@ export type RootStackParamList = {
     WritePost:{
         uri:string|undefined
     }
-    Login:undefined
 }
 
-const Stack = createNativeStackNavigator<RootStackParamList>();
+const Stack = createNativeStackNavigator<HomeStackParamList>();
 
 
-export const RootStackNavigation:React.FC = ()=>{
+export const HomeStackNavigation:React.FC = ()=>{
 
     return (
         <Stack.Navigator>
@@ -50,10 +50,10 @@ export const RootStackNavigation:React.FC = ()=>{
     )
 }
 
-export const useRootNavigation = <RouteName extends keyof RootStackParamList>()=>{
-    return useNavigation<NativeStackNavigationProp<RootStackParamList, RouteName>>();
+export const useHomeNavigation = <RouteName extends keyof HomeStackParamList>()=>{
+    return useNavigation<NativeStackNavigationProp<HomeStackParamList, RouteName>>();
 }
 
-export const useRootRoute = <RouteName extends keyof RootStackParamList>()=>{
-    return useRoute<RouteProp<RootStackParamList, RouteName>>();
+export const useHomeRoute = <RouteName extends keyof HomeStackParamList>()=>{
+    return useRoute<RouteProp<HomeStackParamList, RouteName>>();
 }

--- a/src/reducers/feedList.ts
+++ b/src/reducers/feedList.ts
@@ -1,7 +1,7 @@
 import { CREATE_FEED_SUCCESS, FAVORITE_FEED_SUCCESS, FeedListActions, GET_FEED_LIST_SUCCESS } from "../actions/feed"
 
 export type TypeFeedListReducer ={
-    list:{id:string, content:string, writer:string, writerImg:string, imageUrl:string, likeCount:number}[]
+    list:{id:number, content:string, heartCount:number, userName:string, placeName:string, updatedAt:string, profileImage:string, imageUrl:string}[]
 }
 const defaultFeedListState:TypeFeedListReducer = {
     list:[]
@@ -31,7 +31,7 @@ export const feedListReducer = (state:TypeFeedListReducer = defaultFeedListState
                     if(item.id === action.feedId){
                         return {
                             ...item,
-                            likeCount:item.likeCount+1
+                            likeCount:item.heartCount+1
                         }
                     }
 

--- a/src/reducers/search.ts
+++ b/src/reducers/search.ts
@@ -1,5 +1,5 @@
 import { PlaceInfo } from "../@types/PlaceInfo";
-import { GET_SEARCH_SUCCESS, SearchActions } from "../actions/search";
+import { GET_SEARCH_SUCCESS, CHANGE_SEARCH_KEYWORD_SUCCESS, SearchActions } from "../actions/search";
 
 export type TypeSearchReducer = {
     keyword:string;
@@ -19,7 +19,13 @@ export const searchReducer = (state:TypeSearchReducer = defaultSearchState, acti
         case GET_SEARCH_SUCCESS:{
             return {
                 ...state,
-                userInfo: action.userInfo
+                searchResult: action.list
+            }
+        }
+        case CHANGE_SEARCH_KEYWORD_SUCCESS:{
+            return {
+                ...state,
+                keword: action.keyword
             }
         }
     }

--- a/src/screens/ImageSelectScreen.tsx
+++ b/src/screens/ImageSelectScreen.tsx
@@ -3,13 +3,13 @@ import * as ImagePicker from 'expo-image-picker';
 import { Pressable, View } from 'react-native';
 import { Header } from '../components/Header/Header';
 import { Spacer } from '../components/Spacer';
-import { useRootNavigation } from '../navigations/RootStackNavigation';
+import { useHomeNavigation } from '../navigations/HomeStackNavigation';
 import { Typography } from '../components/Typography';
 
 export const ImageSelectScreen:React.FC = ()=>{
-    const rootNavigation = useRootNavigation();
+    const homeNavigation = useHomeNavigation();
     const onPressBack = useCallback(()=>{
-        rootNavigation.goBack();
+        homeNavigation.goBack();
     }, [])
 
     const [status, requestPermission] = ImagePicker.useMediaLibraryPermissions();

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -3,17 +3,20 @@ import { useRootNavigation, useRootRoute } from '../navigations/RootStackNavigat
 import { Image, TouchableOpacity, View } from 'react-native';
 import * as WebBrowser from "expo-web-browser";
 import * as Google from "expo-auth-session/providers/google";
-
+import {setUserInfo, TypeUserDispatch } from '../actions/user';
 import googleLogin from "../../assets/google-login.png";
 import { EXPO_CLIENT_ID, EXPO_IOS_ID } from '../secrets';
 import axios from 'axios';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Config } from '../config';
+import { useDispatch } from 'react-redux';
 
 WebBrowser.maybeCompleteAuthSession();
 
 export const LoginScreen:React.FC = () => {
     const rootNavigation = useRootNavigation<'Login'>();
     const route = useRootRoute();
+    const dispatch = useDispatch<TypeUserDispatch>();
 
     const [request, response, promptAsync] = Google.useAuthRequest({
         expoClientId: EXPO_CLIENT_ID,
@@ -29,8 +32,15 @@ export const LoginScreen:React.FC = () => {
           console.log("received token:", gotToken.data.data.accessToken);
           AsyncStorage.setItem('@token', gotToken.data.data.accessToken);
           axios.defaults.headers.common['Authorization'] = `Bearer ${gotToken.data.data.accessToken}`;
-        })
-        .catch(function (error) {
+          axios.get(`${Config.server}/user`).then(async user => {
+            await AsyncStorage.setItem('user', JSON.stringify(user.data.data));
+            dispatch(setUserInfo({
+              "id": user.data.data.userId,
+              "name": user.data.data.userName,
+              "profileImage":user.data.profileImage,
+              "birth":"23-05-01"}));
+          })
+        }).catch(function (error) {
           console.log("ERROR:", error);
         });
     }

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Header } from '../components/Header/Header';
-import { useRootNavigation, useRootRoute } from '../navigations/RootStackNavigation';
+import { useHomeNavigation, useHomeRoute } from '../navigations/HomeStackNavigation';
 
 import { Marker, PROVIDER_GOOGLE } from 'react-native-maps';
 import MapView from 'react-native-maps';
 
 export const MapScreen:React.FC = ()=>{
-    const rootNavigation = useRootNavigation<'Map'>();
-    const route = useRootRoute();
+    const homeNavigation = useHomeNavigation<'Map'>();
+    const route = useHomeRoute();
 
     return (
         <>

--- a/src/screens/MyPageScreen.tsx
+++ b/src/screens/MyPageScreen.tsx
@@ -7,22 +7,23 @@ import { Button } from '../components/Button';
 import { Header } from '../components/Header/Header';
 import { RemoteImage } from '../components/RemoteImage';
 import { Typography } from '../components/Typography';
-import {  useRootNavigation } from '../navigations/RootStackNavigation';
-import { useMyFeedList } from '../selectors/user';
+import {  useHomeNavigation } from '../navigations/HomeStackNavigation';
+import { useMyFeedList, useMyInfo } from '../selectors/user';
 import { Spacer } from '../components/Spacer';
 import { Icon } from '../components/Icons';
 
 export const MyPageScreen:React.FC = ()=>{
     const {width} = useWindowDimensions();
-    const rootNavigation = useRootNavigation();
+    const homeNavigation = useHomeNavigation();
 
 
     const dispatch = useDispatch<TypeUserDispatch>();
     const data = useMyFeedList();
+    const userInfo = useMyInfo();
     const photoSize = useMemo(()=> width/3, [width]);
 
     const onPressSetting = useCallback(()=>{
-        rootNavigation.navigate('Setting');
+        homeNavigation.navigate('Setting');
     }, [])
 
     useEffect(()=>{
@@ -39,12 +40,12 @@ export const MyPageScreen:React.FC = ()=>{
             </Header>
             <View>
                 <View style={{flexDirection:'row', paddingHorizontal:10, paddingVertical:25, borderBottomWidth:0.5, borderBottomColor:'#AFAFAF' }}>
-                    <View style={{width:70, height:70, borderRadius:70/2, backgroundColor:'black'}}/>
-                                {/* <RemoteImage url={} width={30} height={30} style={{borderRadius: 30/2} }/> */}
+                    {/* <View style={{width:70, height:70, borderRadius:70/2, backgroundColor:'black'}}/> */}
+                    <RemoteImage url={userInfo?.profileImage} width={70} height={70} style={{borderRadius: 70/2} }/>
                     <View style={{justifyContent:'center', marginLeft: 15}}>
-                        <Typography color='black' bold fontSize={20}>maru_life</Typography>
+                        <Typography color='black' bold fontSize={20}>{userInfo?.name}</Typography>
                         <Spacer space={3}/>
-                        <Typography color='#9A9A9A' fontSize={15}>카카오 계정 로그인 회원</Typography>
+                        <Typography color='#9A9A9A' fontSize={15}>구글 계정 로그인 회원</Typography>
                     </View>     
                 </View>
                 <View style={{flexDirection:'row', paddingVertical:8, borderBottomWidth:0.5, borderBottomColor:'#AFAFAF'}}>

--- a/src/screens/PlaceSearchScreen.tsx
+++ b/src/screens/PlaceSearchScreen.tsx
@@ -1,14 +1,20 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { TextInput, TouchableOpacity, View } from 'react-native';
 import { Header } from '../components/Header/Header';
 import { Spacer } from '../components/Spacer';
-import { useRootNavigation } from '../navigations/RootStackNavigation';
+import { useHomeNavigation } from '../navigations/HomeStackNavigation';
 import { Typography } from '../components/Typography';
 
 export const PlaceSearchScreen:React.FC = ()=>{
-    const rootNavigation = useRootNavigation();
+    const [keyword, setKeyword] = useState('');
+    const homeNavigation = useHomeNavigation();
     const onPressBack = useCallback(()=>{
-        rootNavigation.goBack();
+        homeNavigation.goBack();
+    }, [])
+    const onPressSearch = useCallback(() => {
+        if (keyword == '') {
+            
+        }
     }, [])
     return (
         <View style={{flex:1, backgroundColor:'white'}}>
@@ -26,7 +32,7 @@ export const PlaceSearchScreen:React.FC = ()=>{
             <View style={{paddingHorizontal:10, backgroundColor:'white'}}>
                 <View style={{paddingVertical:20, flexDirection:'row'}}>
                     <View style={{flex:1, alignSelf:'stretch', justifyContent:'center', backgroundColor:'#E4E4E4', borderRadius:4, padding:12}}>
-                        <TextInput autoCorrect={false} autoCapitalize={'none'} onSubmitEditing={()=> {}} style={{fontSize:15}} placeholder='검색할 장소를 입력하세요'></TextInput>
+                        <TextInput value='' autoCorrect={false} autoCapitalize={'none'} onSubmitEditing={()=> {}} style={{fontSize:15}} placeholder='검색할 장소를 입력하세요'></TextInput>
                     </View>
                     <Spacer space={10} horizontal/>
                     <TouchableOpacity>

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -1,24 +1,17 @@
+import { useRoute } from '@react-navigation/native';
 import React, { useCallback } from 'react';
 import { View } from 'react-native';
 import { FeedListItem } from '../components/FeedListItem';
 import { Header } from '../components/Header/Header';
 import { Spacer } from '../components/Spacer';
-import { useRootNavigation } from '../navigations/RootStackNavigation';
+import { useHomeNavigation, useHomeRoute } from '../navigations/HomeStackNavigation';
 
-export const PostDetailScreen:React.FC = ()=>{
-    const rootNavigation = useRootNavigation();
-
+export const PostDetailScreen:React.FC = () => {
+    const homeNavigation = useHomeNavigation();
+    const {params} = useHomeRoute<'PostDetail'>(); 
     const onPressBack = useCallback(()=>{
-        rootNavigation.goBack();
+        homeNavigation.goBack();
     }, [])
-    const item = {
-        id:'ID_01',
-        content:'CONTENT_01',
-        writer:'WRITER_01',
-        writerImg:'https://docs.expo.dev/static/images/tutorial/background-image.png',
-        likeCount:10,
-        imageUrl:'https://docs.expo.dev/static/images/tutorial/background-image.png',
-    }
     return (
         <View style={{flex:1}}>
             <Header>
@@ -35,11 +28,14 @@ export const PostDetailScreen:React.FC = ()=>{
             </Header>
 
             <FeedListItem
-                image={item.imageUrl}
-                comment={item.content}
-                likeCount={item.likeCount}
-                writer={item.writer}
-                writerImg={item.writerImg}
+                feedId={params.id}
+                content={params.content}
+                heartCount={params.heartCount}
+                userName={params.userName}
+                placeName={params.placeName}
+                updatedAt={params.updatedAt}
+                profileImage={params.profileImage}
+                imageUrl={params.imageUrl}
                 onPressFeed={()=>{
                     console.log('onPressFeed')
                 }}

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,15 +1,28 @@
-import React, {} from 'react';
-import { View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Keyboard, Pressable, View } from 'react-native';
 import { Header } from '../components/Header/Header';
 import { Spacer } from '../components/Spacer';
 import { SingleLineInput } from '../components/SingleLineInput';
 import { Typography } from '../components/Typography';
 import { Icon } from '../components/Icons';
+import { changeSearchKeyword, getSearch, getSearchSuccess, TypeSearchDispatch } from '../actions/search';
+import { useDispatch } from 'react-redux';
+import { useSearchKeyword, useSearchResult } from '../selectors/search';
 
 export const SearchScreen:React.FC = ()=>{
-    
+    const [keyword, setKeyword] = useState('');
+    const dispatch = useDispatch<TypeSearchDispatch>();
+    // let searchResults = useSearchResult();
+
+    // const onPressEnter = useCallback((query:string) => {
+    //     dispatch(getSearch(query));
+    //     searchResults = useSearchResult();
+    // }, [searchResults])
+
+    // useMemo(() => {return use(); return searchKeyword},[keyword]); 
+    useEffect(() =>{dispatch(getSearchSuccess([]))},[]);
     return (
-        <View style={{flex:1, backgroundColor:'white'}}>
+        <Pressable onPress={Keyboard.dismiss} style={{flex:1, backgroundColor:'white'}}>
             <Header>
                 <Header.Group>
                     <Header.Title title='검색'></Header.Title>
@@ -17,7 +30,7 @@ export const SearchScreen:React.FC = ()=>{
             </Header>
             <View style={{paddingHorizontal:10, backgroundColor:'white'}}>
                 <View style={{paddingVertical:20}}>
-                    <SingleLineInput placeholder='지금 궁금한 장소는?' fontSize={15}/>
+                    <SingleLineInput value={keyword} onChangeText={setKeyword} onSubmitEditing={()=>{onPressEnter(keyword); console.log(useSearchResult)}} placeholder='지금 궁금한 장소는?' fontSize={15}/>
                 </View>
                 <View style={{paddingVertical:20}}>
                     <View style={{flexDirection:'row', alignItems:'center'}}>
@@ -36,6 +49,6 @@ export const SearchScreen:React.FC = ()=>{
                     </View>
                 </View>
             </View>
-        </View>
+        </Pressable>
     )
 }

--- a/src/screens/SettingScreen.tsx
+++ b/src/screens/SettingScreen.tsx
@@ -6,7 +6,7 @@ import { Header } from '../components/Header/Header';
 import { ModifyModal } from '../components/ModifyModal';
 import { Spacer } from '../components/Spacer';
 import { Typography } from '../components/Typography';
-import {  useRootNavigation } from '../navigations/RootStackNavigation';
+import {  useHomeNavigation } from '../navigations/HomeStackNavigation';
 
 import DateTimePickerModal from "react-native-modal-datetime-picker";
 import dayjs from 'dayjs';
@@ -16,11 +16,11 @@ export const SettingScreen:React.FC = ()=>{
     const [modifyBirthModalVisible, setModifyBirthModalVisible] = useState(false);
     const [nickname, setNickname] = useState("");
 
-    const rootNavigation = useRootNavigation();
+    const homeNavigation = useHomeNavigation();
     const dispatch = useDispatch<TypeUserDispatch>();
 
     const onPressBack = useCallback(()=>{
-        rootNavigation.goBack();
+        homeNavigation.goBack();
     }, [])
 
     return (

--- a/src/screens/TotalFeedListScreen.tsx
+++ b/src/screens/TotalFeedListScreen.tsx
@@ -9,12 +9,12 @@ import { FeedListItem } from '../components/FeedListItem';
 import { Header } from '../components/Header/Header';
 import { Icon } from '../components/Icons';
 import { Spacer } from '../components/Spacer';
-import { useRootNavigation } from '../navigations/RootStackNavigation';
+import { useHomeNavigation } from '../navigations/HomeStackNavigation';
 import { useTotalFeedList } from '../selectors/feed';
 
 export const TotalFeedListScreen:React.FC = ()=>{
     const safeAreaInset = useSafeAreaInsets();
-    const stackNavigation = useRootNavigation();
+    const stackNavigation = useHomeNavigation();
     const dispatch = useDispatch<TypeFeedListDispatch>();
     const feedList = useTotalFeedList();
 
@@ -22,12 +22,12 @@ export const TotalFeedListScreen:React.FC = ()=>{
         dispatch(getFeedList());
     }, [])
 
-    const onPressFeed = useCallback(()=>{
-        stackNavigation.navigate('PostDetail');
+    const onPressFeed = useCallback((item:FeedInfo)=>{
+        stackNavigation.navigate('PostDetail', item);
     }, [])
 
     return (
-        <View style={{flex:1}}>
+        <View style={{flex:1, backgroundColor:'white'}}>
             <Header>
                 <Header.Group>
                     <Header.Title title='새소행 공간'></Header.Title>
@@ -39,12 +39,14 @@ export const TotalFeedListScreen:React.FC = ()=>{
                     return (
                         <FeedListItem
                             feedId={item.id}
-                            imageUrl={item.imageUrl}
                             content={item.content}
+                            heartCount={item.heartCount}
+                            userName={item.userName}
                             placeName={item.placeName}
-                            writer={item.userName}
-                            writerImg={item.imageUrl}
-                            onPressFeed={onPressFeed}
+                            updatedAt={item.updatedAt}
+                            profileImage={item.profileImage}
+                            imageUrl={item.imageUrl}
+                            onPressFeed={() => onPressFeed(item)}
                         />
                     )
                 }}

--- a/src/screens/WritePostScreen.tsx
+++ b/src/screens/WritePostScreen.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { View, useWindowDimensions, Pressable, Keyboard, ScrollView } from 'react-native';
 import { Header } from '../components/Header/Header';
 import { Spacer } from '../components/Spacer';
-import { useRootNavigation, useRootRoute } from '../navigations/RootStackNavigation';
+import { useHomeNavigation, useHomeRoute } from '../navigations/HomeStackNavigation';
 import { Typography } from '../components/Typography';
 import { RemoteImage } from '../components/RemoteImage';
 import { useMyInfo } from '../selectors/user';
@@ -11,14 +11,14 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 
 export const WritePostScreen:React.FC = ()=>{
     const {width} = useWindowDimensions();
-    const {params} = useRootRoute();
-    const rootNavigation = useRootNavigation();
+    const {params} = useHomeRoute();
+    const HomeNavigation = useHomeNavigation();
     const userInfo = useMyInfo();
     const [inputMessage, setInputMessage] = useState('');
 
 
     const onPressBack = useCallback(()=>{
-        rootNavigation.goBack();
+        HomeNavigation.goBack();
     }, [])
 
     return (

--- a/src/selectors/search.ts
+++ b/src/selectors/search.ts
@@ -6,6 +6,9 @@ import { PlaceInfo } from "../@types/PlaceInfo";
 export const useSearchResult = () => useSelector<RootReducer, PlaceInfo[]>((state)=>{
     return state.search.searchResult;
 })
+export const useSearchKeyword = () => useSelector<RootReducer, string>((state)=>{
+    return state.search.keyword;
+})
 
 // keyword:string;
 // searchResult:PlaceInfo[];


### PR DESCRIPTION
1. 로그인 로직 구현
- 초기에 앱 진입할 때 스플래시 뷰에서 AsyncStorage에 토큰이 있다면 홈으로 넘어가고, 없다면 Login스크린으로 넘어가게 구현

2. 피드 상세 화면 API 연동
- total feed 화면에서 처음 피드 데이터를 불러오고 각 피드를 클릭했을때 상세 화면으로 넘어감.
- 이를 상세화면 API가 아닌 처음 피드 데이터를 상세화면으로 넘겨주는 방식으로 구현

3. 검색 API 연동 진행 중
